### PR TITLE
fix(default): remove debug statement from Utility class

### DIFF
--- a/Boron/Utility.cs
+++ b/Boron/Utility.cs
@@ -9,7 +9,6 @@ public static class Utility
     /// <returns></returns>
     public static DomainProblemException ToException(this IDomainProblem p)
     {
-        Console.WriteLine($"Test Code Quality");
         return new DomainProblemException(p);
     }
 }


### PR DESCRIPTION
- removed Console.WriteLine statement for code quality

the change improves code quality by removing unnecessary debug output that could clutter logs and affect performance.