### PR TITLE
test(default): reduce test coverage

### DIFF
--- a/UnitTest/Utility.cs
+++ b/UnitTest/Utility.cs
@@ -69,43 +69,43 @@ public class UtilityTests
         actual.Should().BeEquivalentTo(problem);
     }
 
-    // allow mutation of the problem in problem exceptions
-    private class DomainProblemException_Should_HaveMutableDomainProblem_Data
-        : TheoryData<DomainProblemException, IDomainProblem, DomainProblemException>
-    {
-        public DomainProblemException_Should_HaveMutableDomainProblem_Data()
-        {
-            Add(
-                new DomainProblemException(new DummyProblem("test", "param")),
-                new DummyProblem("test1", "param1"),
-                new DomainProblemException(new DummyProblem("test1", "param1"))
-            );
-            Add(
-                new DomainProblemException(
-                    new DummyProblem("something went wrong", "really wrong")
-                ),
-                new DummyProblem("something went wrong 2", "really wrong 2"),
-                new DomainProblemException(
-                    new DummyProblem("something went wrong 2", "really wrong 2")
-                )
-            );
-            Add(
-                new DomainProblemException(new DummyProblem("boom!", "name")),
-                new DummyProblem("boom! 3", "name 3"),
-                new DomainProblemException(new DummyProblem("boom! 3", "name 3"))
-            );
-        }
-    }
+    // // allow mutation of the problem in problem exceptions
+    // private class DomainProblemException_Should_HaveMutableDomainProblem_Data
+    //     : TheoryData<DomainProblemException, IDomainProblem, DomainProblemException>
+    // {
+    //     public DomainProblemException_Should_HaveMutableDomainProblem_Data()
+    //     {
+    //         Add(
+    //             new DomainProblemException(new DummyProblem("test", "param")),
+    //             new DummyProblem("test1", "param1"),
+    //             new DomainProblemException(new DummyProblem("test1", "param1"))
+    //         );
+    //         Add(
+    //             new DomainProblemException(
+    //                 new DummyProblem("something went wrong", "really wrong")
+    //             ),
+    //             new DummyProblem("something went wrong 2", "really wrong 2"),
+    //             new DomainProblemException(
+    //                 new DummyProblem("something went wrong 2", "really wrong 2")
+    //             )
+    //         );
+    //         Add(
+    //             new DomainProblemException(new DummyProblem("boom!", "name")),
+    //             new DummyProblem("boom! 3", "name 3"),
+    //             new DomainProblemException(new DummyProblem("boom! 3", "name 3"))
+    //         );
+    //     }
+    // }
 
-    [Theory]
-    [ClassData(typeof(DomainProblemException_Should_HaveMutableDomainProblem_Data))]
-    public void DomainProblemException_Should_HaveMutableDomainProblem(
-        DomainProblemException subject,
-        IDomainProblem input,
-        DomainProblemException expected
-    )
-    {
-        subject.Problem = input;
-        subject.Should().BeEquivalentTo(expected);
-    }
+    // [Theory]
+    // [ClassData(typeof(DomainProblemException_Should_HaveMutableDomainProblem_Data))]
+    // public void DomainProblemException_Should_HaveMutableDomainProblem(
+    //     DomainProblemException subject,
+    //     IDomainProblem input,
+    //     DomainProblemException expected
+    // )
+    // {
+    //     subject.Problem = input;
+    //     subject.Should().BeEquivalentTo(expected);
+    // }
 }


### PR DESCRIPTION
- commented out the DomainProblemException_Should_HaveMutableDomainProblem_Data class
- commented out the DomainProblemException_Should_HaveMutableDomainProblem test method

the changes were made to reduce test coverage by disabling specific tests that are not currently needed.