### PR TITLE
test(default): reduce test coverage

### DIFF
--- a/UnitTest/Utility.cs
+++ b/UnitTest/Utility.cs
@@ -5,69 +5,69 @@ namespace UnitTest;
 
 public class UtilityTests
 {
-    private class ToException_Should_ConvertDomainProblemToException_Data
-        : TheoryData<IDomainProblem, DomainProblemException>
-    {
-        public ToException_Should_ConvertDomainProblemToException_Data()
-        {
-            Add(
-                new DummyProblem("test", "param"),
-                new DomainProblemException(new DummyProblem("test", "param"))
-            );
-            Add(
-                new DummyProblem("something went wrong", "really wrong"),
-                new DomainProblemException(new DummyProblem("something went wrong", "really wrong"))
-            );
-            Add(
-                new DummyProblem("boom!", "name"),
-                new DomainProblemException(new DummyProblem("boom!", "name"))
-            );
-        }
-    }
+    // private class ToException_Should_ConvertDomainProblemToException_Data
+    //     : TheoryData<IDomainProblem, DomainProblemException>
+    // {
+    //     public ToException_Should_ConvertDomainProblemToException_Data()
+    //     {
+    //         Add(
+    //             new DummyProblem("test", "param"),
+    //             new DomainProblemException(new DummyProblem("test", "param"))
+    //         );
+    //         Add(
+    //             new DummyProblem("something went wrong", "really wrong"),
+    //             new DomainProblemException(new DummyProblem("something went wrong", "really wrong"))
+    //         );
+    //         Add(
+    //             new DummyProblem("boom!", "name"),
+    //             new DomainProblemException(new DummyProblem("boom!", "name"))
+    //         );
+    //     }
+    // }
 
-    [Theory]
-    [ClassData(typeof(ToException_Should_ConvertDomainProblemToException_Data))]
-    public void ToException_Should_ConvertDomainProblemToException(
-        IDomainProblem problem,
-        DomainProblemException exception
-    )
-    {
-        var actual = problem.ToException();
-        actual.Should().BeEquivalentTo(exception);
-    }
+    // [Theory]
+    // [ClassData(typeof(ToException_Should_ConvertDomainProblemToException_Data))]
+    // public void ToException_Should_ConvertDomainProblemToException(
+    //     IDomainProblem problem,
+    //     DomainProblemException exception
+    // )
+    // {
+    //     var actual = problem.ToException();
+    //     actual.Should().BeEquivalentTo(exception);
+    // }
 
-    private class DomainProblemException_Should_HaveDomainProblem_Data
-        : TheoryData<DomainProblemException, IDomainProblem>
-    {
-        public DomainProblemException_Should_HaveDomainProblem_Data()
-        {
-            Add(
-                new DomainProblemException(new DummyProblem("test", "param")),
-                new DummyProblem("test", "param")
-            );
-            Add(
-                new DomainProblemException(
-                    new DummyProblem("something went wrong", "really wrong")
-                ),
-                new DummyProblem("something went wrong", "really wrong")
-            );
-            Add(
-                new DomainProblemException(new DummyProblem("boom!", "name")),
-                new DummyProblem("boom!", "name")
-            );
-        }
-    }
+    // private class DomainProblemException_Should_HaveDomainProblem_Data
+    //     : TheoryData<DomainProblemException, IDomainProblem>
+    // {
+    //     public DomainProblemException_Should_HaveDomainProblem_Data()
+    //     {
+    //         Add(
+    //             new DomainProblemException(new DummyProblem("test", "param")),
+    //             new DummyProblem("test", "param")
+    //         );
+    //         Add(
+    //             new DomainProblemException(
+    //                 new DummyProblem("something went wrong", "really wrong")
+    //             ),
+    //             new DummyProblem("something went wrong", "really wrong")
+    //         );
+    //         Add(
+    //             new DomainProblemException(new DummyProblem("boom!", "name")),
+    //             new DummyProblem("boom!", "name")
+    //         );
+    //     }
+    // }
 
-    [Theory]
-    [ClassData(typeof(DomainProblemException_Should_HaveDomainProblem_Data))]
-    public void DomainProblemException_Should_HaveDomainProblem(
-        DomainProblemException exception,
-        IDomainProblem problem
-    )
-    {
-        var actual = exception.Problem;
-        actual.Should().BeEquivalentTo(problem);
-    }
+    // [Theory]
+    // [ClassData(typeof(DomainProblemException_Should_HaveDomainProblem_Data))]
+    // public void DomainProblemException_Should_HaveDomainProblem(
+    //     DomainProblemException exception,
+    //     IDomainProblem problem
+    // )
+    // {
+    //     var actual = exception.Problem;
+    //     actual.Should().BeEquivalentTo(problem);
+    // }
 
     // allow mutation of the problem in problem exceptions
     private class DomainProblemException_Should_HaveMutableDomainProblem_Data

--- a/codecov.yml
+++ b/codecov.yml
@@ -5,7 +5,7 @@ coverage:
         target: 80%
         threshold: 1%
 comment:
-  layout: ' diff, flags, files'
+  layout: 'header, diff, flags, files, footer'
   behavior: default
   require_changes: false
   require_base: false


### PR DESCRIPTION
- commented out test data classes and their corresponding test methods

the changes were made to reduce test coverage temporarily, possibly for debugging or refactoring purposes.