### PR TITLE
fix: incorrect version bump for releaser

### DIFF
--- a/atomi_release.yaml
+++ b/atomi_release.yaml
@@ -32,7 +32,7 @@ plugins:
   - module: '@semantic-release/exec'
     version: 6.0.3
     config:
-      prepareCmd: scripts/ci/update_version.sh ${nextRelease.version} Boron
+      prepareCmd: scripts/update_version.sh ${nextRelease.version} Boron
 
   # Commit Additional Changes & Artifacts
   - module: '@semantic-release/git'


### PR DESCRIPTION
- updated the prepare command in atomi_release.yaml
- changed the script path from scripts/ci/update_version.sh to scripts/update_version.sh

the previous script path was incorrect, leading to potential issues in version updating during the release process.